### PR TITLE
b242: Dashboard LCARS fixes - swept elbows, palette sync, pointcloud …

### DIFF
--- a/rPi controller/CHANGELOG.md
+++ b/rPi controller/CHANGELOG.md
@@ -6,6 +6,7 @@ FORMAT: `YYYY-MM-DD  <summary>`
 
 ## Entries
 
+2026-01-01  v0.8.5 b242: Dashboard: Fixed LCARS swept elbows with proper inner curve cutouts (::after pseudo-elements); added dynamic palette system syncing to user's System.Palette selection; fixed pointcloud_viewer to handle 'frame' message type and array-based points.
 2026-01-01  v0.8.5 b241: Dashboard: Rebuilt LCARS per Manifesto - proper swept elbows (thick→thin frames), cap buttons, 3 font sizes, minimalist layout; simpler, more authentic TNG styling.
 2026-01-01  v0.8.5 b240: Dashboard: LCARS theme for dashboard and point cloud viewer - authentic Star Trek TNG styling with distinctive color palette (orange/peach/tan/blue/purple), curved panels, sidebar navigation, stardate timestamps.
 2026-01-01  v0.8.5 b239: Dashboard W2: Enhanced config view with all menu categories (12 tabs), collapsible sections, search/filter; MarsMenu.get_all_config() exports menu items to dashboard; config pushed every 2s.

--- a/rPi controller/controller.ini
+++ b/rPi controller/controller.ini
@@ -49,7 +49,7 @@ blink_frame_divisor = 2
 engineering_lcars = true
 
 [eyes]
-shape = 5
+shape = 6
 spacing_offset = 10
 center_offset = 17
 eyelid_angle = 0

--- a/rPi controller/static/dashboard.html
+++ b/rPi controller/static/dashboard.html
@@ -25,16 +25,18 @@
         }
         
         :root {
-            /* LCARS color palette - limited to 5 purposeful colors */
+            /* LCARS color palette - default Classic TNG colors */
+            /* These are dynamically updated based on user's palette selection */
             --lcars-black: #000000;
-            --lcars-orange: #ff9900;      /* Primary: active/important */
-            --lcars-peach: #ffcc99;       /* Secondary: data display */
-            --lcars-tan: #cc9966;         /* Tertiary: frames/structure */
-            --lcars-blue: #9999ff;        /* Quaternary: interactive */
-            --lcars-purple: #cc99cc;      /* Quinary: status/info */
+            --lcars-orange: #ff8800;      /* Primary: active/important */
+            --lcars-peach: #ff8866;       /* Secondary: data display */
+            --lcars-tan: #ffaa00;         /* Tertiary: frames/structure */
+            --lcars-blue: #cc99ff;        /* Quaternary: interactive (violet) */
+            --lcars-purple: #99ccff;      /* Quinary: status/info (ice) */
+            --lcars-sunflower: #ffcc99;   /* Light accent */
             
             /* Semantic (derived from palette) */
-            --lcars-alert: #cc4444;       /* Alert state */
+            --lcars-alert: #ff5555;       /* Alert state (tomato) */
             --lcars-ok: #99cc66;          /* OK state */
             
             /* Spacing constants (invisible grid) */
@@ -51,7 +53,7 @@
         body {
             font-family: 'Antonio', 'Helvetica Neue', Arial, sans-serif;
             background: var(--lcars-black);
-            color: var(--lcars-peach);
+            color: var(--lcars-sunflower);
             min-height: 100vh;
             overflow-x: hidden;
         }
@@ -73,16 +75,30 @@
             gap: var(--frame-gap);
         }
         
-        /* Left swept elbow - thick to thin */
+        /* Left swept elbow - thick to thin (LCARS cornerstone)
+           The swept creates an L-shaped elbow with inner curve cutout */
         .lcars-header-swept {
             width: 180px;
             height: 60px;
             background: var(--lcars-orange);
             border-bottom-right-radius: var(--swept-radius);
             flex-shrink: 0;
+            position: relative;
         }
         
-        /* Top bar - extends across */
+        /* Inner curve cutout - creates the swept effect */
+        .lcars-header-swept::after {
+            content: '';
+            position: absolute;
+            right: 0;
+            bottom: 0;
+            width: 40px;
+            height: 20px;
+            background: var(--lcars-black);
+            border-top-left-radius: var(--swept-radius);
+        }
+        
+        /* Top bar - extends across (thinner than elbow = thick→thin transition) */
         .lcars-header-bar {
             flex: 1;
             height: 40px;
@@ -198,11 +214,23 @@
             min-height: 20px;
         }
         
-        /* Bottom swept elbow */
+        /* Bottom swept elbow with inner curve cutout */
         .lcars-sidebar-swept {
             height: 60px;
             background: var(--lcars-tan);
             border-top-right-radius: var(--swept-radius);
+            position: relative;
+        }
+        
+        .lcars-sidebar-swept::after {
+            content: '';
+            position: absolute;
+            right: 0;
+            top: 0;
+            width: 40px;
+            height: 20px;
+            background: var(--lcars-black);
+            border-bottom-left-radius: var(--swept-radius);
         }
         
         /* ================================================================
@@ -619,10 +647,23 @@
             margin-top: var(--frame-gap);
         }
         
+        /* Footer swept elbow - bottom left corner with inner cutout */
         .lcars-footer-swept {
             width: 180px;
             background: var(--lcars-tan);
             border-top-right-radius: var(--swept-radius);
+            position: relative;
+        }
+        
+        .lcars-footer-swept::after {
+            content: '';
+            position: absolute;
+            right: 0;
+            top: 0;
+            width: 40px;
+            height: 10px;
+            background: var(--lcars-black);
+            border-bottom-left-radius: var(--swept-radius);
         }
         
         .lcars-footer-bar {
@@ -1098,8 +1139,86 @@
                 updateTelemetry(data.data);
             } else if (data.type === 'config') {
                 config = data.data;
+                applyPalette();  // Apply LCARS palette from config
                 renderConfig();
             }
+        }
+        
+        // =================================================================
+        // LCARS Palettes (from display_thread.py)
+        // =================================================================
+        
+        const LCARS_PALETTES = {
+            'Classic': {
+                orange: '#ff8800',
+                gold: '#ffaa00',
+                peach: '#ff8866',
+                sunflower: '#ffcc99',
+                violet: '#cc99ff',
+                lilac: '#cc55ff',
+                almond: '#ffaa90',
+                ice: '#99ccff',
+                sky: '#aaaaff',
+                tomato: '#ff5555',
+            },
+            'Nemesis': {
+                orange: '#6699ff',
+                gold: '#88bbff',
+                peach: '#2266ff',
+                sunflower: '#ebf0ff',
+                violet: '#9966cc',
+                lilac: '#9966cc',
+                almond: '#ccaa88',
+                ice: '#88bbff',
+                sky: '#6699ff',
+                tomato: '#cc2233',
+            },
+            'LwrDecks': {
+                orange: '#ff7700',
+                gold: '#ff9911',
+                peach: '#ffaa44',
+                sunflower: '#ffeecc',
+                violet: '#ff4400',
+                lilac: '#cc5500',
+                almond: '#ffcc99',
+                ice: '#ffeecc',
+                sky: '#ffcc99',
+                tomato: '#ff4400',
+            },
+            'PADD': {
+                orange: '#5588ee',
+                gold: '#7799dd',
+                peach: '#455580',
+                sunflower: '#99ccff',
+                violet: '#88ffff',
+                lilac: '#66ccff',
+                almond: '#99ccff',
+                ice: '#88ffff',
+                sky: '#66ccff',
+                tomato: '#ff3500',
+            }
+        };
+        
+        function applyPalette() {
+            // Get palette name from System config
+            let paletteName = 'Classic';
+            if (config && config.System && config.System.Palette) {
+                paletteName = config.System.Palette;
+            }
+            
+            const palette = LCARS_PALETTES[paletteName] || LCARS_PALETTES['Classic'];
+            const root = document.documentElement;
+            
+            // Apply palette colors to CSS variables
+            root.style.setProperty('--lcars-orange', palette.orange);
+            root.style.setProperty('--lcars-tan', palette.gold);
+            root.style.setProperty('--lcars-peach', palette.peach);
+            root.style.setProperty('--lcars-sunflower', palette.sunflower);
+            root.style.setProperty('--lcars-blue', palette.violet);
+            root.style.setProperty('--lcars-purple', palette.ice);
+            root.style.setProperty('--lcars-alert', palette.tomato);
+            
+            console.log('Applied LCARS palette:', paletteName);
         }
         
         // =================================================================

--- a/rPi controller/static/pointcloud_viewer.html
+++ b/rPi controller/static/pointcloud_viewer.html
@@ -657,8 +657,9 @@
         }
         
         function handleMessage(data) {
-            if (data.type === 'pointcloud') {
-                updatePointCloud(data.data);
+            // Server sends type='frame' with points as [[x,y,z], ...] arrays
+            if (data.type === 'frame') {
+                updatePointCloud(data);
             }
         }
         
@@ -667,6 +668,7 @@
         // =================================================================
         
         function updatePointCloud(data) {
+            // Points come as array of [x, y, z] arrays from server
             if (!data.points || data.points.length === 0) return;
             
             const points = data.points;
@@ -676,16 +678,17 @@
             let minRange = Infinity, maxRange = 0;
             
             for (let i = 0; i < points.length; i++) {
-                const p = points[i];
+                const p = points[i];  // [x, y, z] array
                 const idx = i * 3;
                 
                 // Convert to scene coords (swap Y/Z for Three.js)
-                positions[idx] = p.x;
-                positions[idx + 1] = p.z;
-                positions[idx + 2] = -p.y;
+                // Server sends [x, y, z] where y is forward, z is up
+                positions[idx] = p[0];      // x stays x
+                positions[idx + 1] = p[2];  // scene Y = data Z (up)
+                positions[idx + 2] = -p[1]; // scene Z = -data Y (forward)
                 
                 // Track range
-                const range = Math.sqrt(p.x * p.x + p.y * p.y + p.z * p.z);
+                const range = Math.sqrt(p[0] * p[0] + p[1] * p[1] + p[2] * p[2]);
                 minRange = Math.min(minRange, range);
                 maxRange = Math.max(maxRange, range);
                 


### PR DESCRIPTION
…viewer

- Fixed LCARS swept elbows with proper inner curve cutouts using ::after pseudo-elements (header, sidebar, footer)
- Added LCARS_PALETTES object with all 4 palettes (Classic, Nemesis, LwrDecks, PADD)
- Added applyPalette() function that syncs dashboard colors to user's System.Palette selection from config
- Fixed pointcloud_viewer.html to handle 'frame' message type (was expecting 'pointcloud')
- Fixed pointcloud_viewer.html array-based point access (p[0], p[1], p[2]) instead of object properties (p.x, p.y, p.z)